### PR TITLE
build: install data files in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,6 @@ setup(
     description='An agent based model to model land use',
     long_description=readme(),
     install_requires=get_requirements(),
+    include_package_data=True,
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4'
 )


### PR DESCRIPTION
While installing from a fresh machine/container, the data files
specified in the MANIFEST.in file were not installed.  This appears to
skip the files in janus/tests/data/*, and farther down the installation
process causes the DATA_FILE lookup here:

https://github.com/ksshannon/janus/blob/e863eb8e0cba8b0fdd3b59b9ee574fc1d6d642b7/janus/install_supplement.py#L26

to raise a KeyError.

According to:

https://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files

there are a few ways to handle this.  Adding `install_package_data=True`
is the simplest, and installed the appropriate files.