### PR TITLE
agents: add encode/decode methods for Farmer()

### DIFF
--- a/janus/agents/farmer.py
+++ b/janus/agents/farmer.py
@@ -3,6 +3,7 @@
 # FileName: farmer.py
 # Purpose: Holds definition of farmer
 
+import json
 
 class Farmer:
     """ The farmer class holds all relevant information about farmer agents. All attributes are optional.
@@ -30,6 +31,14 @@ class Farmer:
         self.alpha = kwargs.get('alpha')
         self.beta = kwargs.get('beta')
 
+    def __eq__(self, other):
+        return self.Age == other.Age and \
+            self.Dist2city == other.Dist2city and \
+            self.LandStatus == other.LandStatus and \
+            self.nFields == other.nFields and \
+            self.alpha == other.alpha and \
+            self.beta == other.beta
+
     def update_age(self):
         """ Updates the age of the agent by one year """
         self.Age += 1
@@ -43,3 +52,11 @@ class Farmer:
          """
         self.alpha += 0.1
         self.beta -= 0.01
+
+    def encode(self):
+        return json.dumps(self.__dict__)
+
+def decode(s):
+    """ Override the values in self with parameters from the json representation of a Farmer"""
+    d = json.loads(s)
+    return Farmer(**d)

--- a/janus/tests/test_agent.py
+++ b/janus/tests/test_agent.py
@@ -1,0 +1,29 @@
+"""
+Created on Wed Aug 14 15:52:44 2019
+
+@author: kendrakaiser
+"""
+
+import json
+import unittest
+import janus.agents.farmer as f
+
+
+class AgentTest(unittest.TestCase):
+
+    def test_eq(self):
+        x = f.Farmer()
+        y = f.Farmer()
+        self.assertTrue(x == y)
+        y = f.Farmer(Age=1)
+        self.assertFalse(x == y)
+
+    def test_farmerEncodeRoundtrip(self):
+        x = f.Farmer(Age=1, Dist2city=2.0, LandStatus="unknown", nFields=1, alpha=0.24, beta=4.0)
+        s = x.encode()
+        y = f.Farmer()
+        y = f.decode(s)
+        self.assertEqual(x, y)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Allow for a simple encoding/decoding strategy for writing agents as
features into netcdf files.

The location of the agent is _not_ encoded, as it doesn't exist within the Farmer class.  It appears(?) to be handled in the DCell class.  It may be that we need to serialize the DCell values, and write a list of agents/farmers.  This is TBD.

Tests added for roundtripping from encode() -> json string -> decode().

The `==`/`__eq__` operator was added as a convenience for testing, with a test for it added as well.